### PR TITLE
Update TAC charter to propose adding a TAC member per project

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ The role of the UCF Technical Advisory Committee (TAC) is to facilitate communic
 
 The TAC chair is elected annually by the members of the TAC. The term of the TAC chair is aligned to the calendar year. Should the TAC chair step down before the end of their term, the TAC will vote in the next meeting to select a temporary chair to finish the current term.
 
-## TAC Members
-
-The prospective TAC Voting Member is recommended by other members of the TAC or the Governing Board, and is subject to a vote. Each project may appoint a member to serve as TAC voting member.
-
 ## Communication
 
 A growing list of communication methods and tools to support the Urban Computing Foundation.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ The role of the UCF Technical Advisory Committee (TAC) is to facilitate communic
 
 The TAC chair is elected annually by the members of the TAC. The term of the TAC chair is aligned to the calendar year. Should the TAC chair step down before the end of their term, the TAC will vote in the next meeting to select a temporary chair to finish the current term.
 
+## TAC Members
+
+The prospective TAC Voting Member is recommended by other members of the TAC or the Governing Board, and is subject to a vote. Each project may appoint a member to serve as TAC voting member.
+
 ## Communication
 
 A growing list of communication methods and tools to support the Urban Computing Foundation.

--- a/TAC_CHARTER.md
+++ b/TAC_CHARTER.md
@@ -73,3 +73,4 @@ This charter (the “Charter”) sets forth the responsibilities and procedures 
 
 #### 8. Amendments ####
 - (a) This charter may be amended by a two-thirds vote of the entire TAC and is subject to approval by LF Projects.
+- (b) The prospective TAC Voting Member is recommended by other members of the TAC or the Governing Board, and is subject to a vote. Each project may appoint a representative to serve as TAC voting member.


### PR DESCRIPTION
This PR proposes to add additional seats to the TAC voting members. Each project admitted to the Urban Computing Foundation will be given one seat in the TAC voting member group. The project team can decide which person to have the seat, and the proposed person shall be approved by the TAC.